### PR TITLE
Fix for excessive post highlighting when slow-scrolling

### DIFF
--- a/appkit/src/main/java/me/grishka/appkit/views/UsableRecyclerView.java
+++ b/appkit/src/main/java/me/grishka/appkit/views/UsableRecyclerView.java
@@ -542,15 +542,16 @@ public class UsableRecyclerView extends RecyclerView implements ObservableListIm
 		}
 
 		@Override
-		public void onShowPress(MotionEvent e){
-			showHighlight();
-		}
+		public void onShowPress(MotionEvent e){ }
 
 		@Override
 		public void onLongPress(MotionEvent e){
 			if(clickingViewHolder instanceof LongClickable && ((LongClickable) clickingViewHolder).onLongClick(e.getX()-clickingViewHolder.itemView.getX(), e.getY()-clickingViewHolder.itemView.getY())){
 				performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
-				endClick();
+				postDelayed(UsableRecyclerView.this::endClick, 32);
+			}
+			if(!didHighlight){
+				showHighlight();
 			}
 		}
 


### PR DESCRIPTION
### Problem
When user is slow-scrolling (keeps finger unmoved during some milliseconds), there are ripple highlight starts (when there is no tap, just scroll). For Moshidon app it looks awful.
### Fix
`UsableRecyclerView:onShowPress` gesture reaction was removed. But when user LongPressed it still highlights.