### PR TITLE
update okhttp and use more efficient data structures

### DIFF
--- a/appkit/build.gradle
+++ b/appkit/build.gradle
@@ -16,7 +16,7 @@ android {
 
 dependencies {
 	api 'androidx.annotation:annotation:1.3.0'
-	api 'com.squareup.okhttp3:okhttp:3.14.9'
+	api 'com.squareup.okhttp3:okhttp:4.12.0'
 	implementation 'me.grishka.litex:recyclerview:1.2.1.1'
 	implementation 'me.grishka.litex:swiperefreshlayout:1.1.0'
 	implementation 'me.grishka.litex:viewpager:1.0.0'

--- a/appkit/src/main/java/me/grishka/appkit/imageloader/downloaders/HTTPImageDownloader.java
+++ b/appkit/src/main/java/me/grishka/appkit/imageloader/downloaders/HTTPImageDownloader.java
@@ -11,6 +11,7 @@ import me.grishka.appkit.imageloader.requests.UrlImageLoaderRequest;
 import me.grishka.appkit.utils.NetworkUtils;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -22,6 +23,8 @@ import okio.Sink;
  * Created by grishka on 28.07.15.
  */
 public class HTTPImageDownloader extends ImageDownloader {
+	public static final int MAX_INFLIGHT_HOST = 5;
+	public static final int MAX_INFLIGHT_TOTAL = 10;
 	private OkHttpClient httpClient;
 
 	@Override
@@ -42,6 +45,9 @@ public class HTTPImageDownloader extends ImageDownloader {
 	public void downloadFile(ImageLoaderRequest _req, OutputStream out, ImageCache.ProgressCallback callback, ImageCache.ImageDownloadInfo info, Runnable onSuccess, Consumer<Throwable> onError){
 		synchronized(this){
 			if(httpClient==null){
+				Dispatcher dispatcher=new Dispatcher();
+				dispatcher.setMaxRequestsPerHost(MAX_INFLIGHT_HOST);
+				dispatcher.setMaxRequests(MAX_INFLIGHT_TOTAL);
 				httpClient=new OkHttpClient.Builder()
 						.connectTimeout(15, TimeUnit.SECONDS)
 						.readTimeout(15, TimeUnit.SECONDS)


### PR DESCRIPTION
I manged to trace the bad performance in the emoji picker a bit further and found that the latest okhttp has a fix for http2 HOL blocking, and that seemed to be a pretty big issue.

Unfortunately that caused quite a bit of lag.
It seems to be better if I use a semaphore to limit the queued requests for okhttp to 15 - so a cancelled request doesn't create that much overhead. Queueing a request seems to be quite expensive. There won't be more than 5 requests per host in flight by default, anyways.

I also think ListImageLoader uses some data structures that get very inefficient for hundreds or thousands of objects. I replaced them with concurrent skip lists, and removed some synchronized calls like this one - https://github.com/grishka/appkit/blob/a69ffd1a7ceac2411bb25c540efd19a0962acb6a/appkit/src/main/java/me/grishka/appkit/imageloader/ListImageLoader.java#L69-L74 - is there any reason I missed why I can't do that?

I'll update this further later today or tomorrow, but it seems to quite well as of now so it's probably the right direction.
I just wanted an experience like the Discord emoji picker, but I think it's now way better so yay!
Just have to refine it a bit further.